### PR TITLE
Do not include numbers in auto-generated NAME value.

### DIFF
--- a/lib/kube/templates/builder.rb
+++ b/lib/kube/templates/builder.rb
@@ -145,7 +145,7 @@ module Kube
       end
 
       def name_from_values(values)
-        values.join("-").gsub(/[^-a-zA-Z0-9]/, "-").gsub(/--+/, "-").gsub(/\A-|-\Z/, "")
+        values.join("-").gsub(/[^-a-zA-Z]/, "-").gsub(/--+/, "-").gsub(/\A-|-\Z/, "")
       end
     end
   end

--- a/spec/kube/templates/builder_spec.rb
+++ b/spec/kube/templates/builder_spec.rb
@@ -9,9 +9,9 @@ defaults:
   replicas: 2
 workers:
   - queues: report_file
-    replicas: 4
     name: builder
   - queues: process_priority,process
+    replicas: 4
 
   EOS
   }
@@ -60,17 +60,17 @@ spec:
     end
 
     it "assigns the variables correctly in each instance" do
-      expect(deployments[0]).to include "replicas: 4"
       expect(deployments[0]).to include "queues: report_file"
       expect(deployments[0]).not_to include "queues: process_priority,process"
 
+      expect(deployments[1]).to include "replicas: 4"
       expect(deployments[1]).to include "queues: process_priority,process"
       expect(deployments[1]).not_to include "queues: report_file"
     end
 
     it "applies default values when not specified in the worker config" do
-      expect(deployments[0]).to include "replicas: 4"
-      expect(deployments[1]).to include "replicas: 2"
+      expect(deployments[0]).to include "replicas: 2"
+      expect(deployments[1]).to include "replicas: 4"
     end
 
     it "applies the NAME value when provided" do
@@ -78,7 +78,7 @@ spec:
     end
 
     it "generates an appropriate NAME when not provided" do
-      expect(deployments[1]).to include "name: resque-process-priority-process"
+      expect(deployments[1]).to match /^\s+name: resque-process-priority-process$/
     end
   end
 end


### PR DESCRIPTION
Fixes issue #1.

When generating the NAME value from the provided variables, if the variables include a value to be 
applied to `replicas` entry, then changing the replica count would change the `name` as well which causes Kubernetes to launch a new deployment, rather than scale the existing one. This resolves that by excluding any value with numbers from the values used to generate the name.

I think this is a better general-purpose solution than having "replicas" be a magic variable name. It has the caveat that there could be a conflict on names with the remaining values used to generate the `name` value.
